### PR TITLE
Fix: css conflict

### DIFF
--- a/src/pages/Insights/components/PronunciationErrorModal.css
+++ b/src/pages/Insights/components/PronunciationErrorModal.css
@@ -136,7 +136,7 @@
     justify-content: center;
 }
 
-.stat-item {
+.modal-stat-item {
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -147,7 +147,7 @@
     backdrop-filter: blur(10px);
 }
 
-.stat-value {
+.modal-stat-value {
     font-size: 2rem;
     font-weight: 700;
     background: linear-gradient(135deg, #3b82f6, #8b5cf6);
@@ -157,7 +157,7 @@
     margin-bottom: 8px;
 }
 
-.stat-label {
+.modal-stat-label {
     color: #94a3b8;
     font-size: 0.875rem;
     font-weight: 500;
@@ -228,8 +228,8 @@
     gap: 8px;
 }
 
-.nationality-item,
-.level-item {
+.modal-nationality-item,
+.modal-level-item {
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -240,14 +240,14 @@
     backdrop-filter: blur(10px);
 }
 
-.nationality-name,
-.level-name {
+.modal-nationality-name,
+.modal-level-name {
     color: #f8fafc;
     font-weight: 500;
 }
 
-.nationality-stats,
-.level-stats {
+.modal-nationality-stats,
+.modal-level-stats {
     color: #94a3b8;
     font-size: 0.875rem;
 }

--- a/src/pages/Insights/components/PronunciationErrorModal.js
+++ b/src/pages/Insights/components/PronunciationErrorModal.js
@@ -103,9 +103,9 @@ const PronunciationErrorModal = ({ isOpen, onClose, refText }) => {
                         <div className="pronunciation-analysis">
                             <div className="analysis-overview">
                                 <div className="overview-stats">
-                                    <div className="stat-item">
-                                        <span className="stat-value">{formatNumber(data.found_documents)}</span>
-                                        <span className="stat-label">발견된 샘플</span>
+                                    <div className="modal-stat-item">
+                                        <span className="modal-stat-value">{formatNumber(data.found_documents)}</span>
+                                        <span className="modal-stat-label">발견된 샘플</span>
                                     </div>
                                 </div>
                             </div>
@@ -139,9 +139,9 @@ const PronunciationErrorModal = ({ isOpen, onClose, refText }) => {
                                                 <h4>국적별 성과 (상위 5개)</h4>
                                                 <div className="nationality-performance">
                                                     {Object.entries(data.error_analysis.nationality_performance).map(([nationality, stats]) => (
-                                                        <div key={nationality} className="nationality-item">
-                                                            <span className="nationality-name">{nationality}</span>
-                                                            <span className="nationality-stats">
+                                                        <div key={nationality} className="modal-nationality-item">
+                                                            <span className="modal-nationality-name">{nationality}</span>
+                                                            <span className="modal-nationality-stats">
                                                                 {formatNumber(stats.count || 0)}개 샘플, 오류율 {formatPercent(stats.avg_error_rate || 0)}
                                                             </span>
                                                         </div>
@@ -155,9 +155,9 @@ const PronunciationErrorModal = ({ isOpen, onClose, refText }) => {
                                                 <h4>레벨별 성과</h4>
                                                 <div className="level-performance">
                                                     {Object.entries(data.error_analysis.level_performance).map(([level, stats]) => (
-                                                        <div key={level} className="level-item">
-                                                            <span className="level-name">{level} 레벨</span>
-                                                            <span className="level-stats">
+                                                        <div key={level} className="modal-level-item">
+                                                            <span className="modal-level-name">{level} 레벨</span>
+                                                            <span className="modal-level-stats">
                                                                 {formatNumber(stats.count || 0)}개 샘플, 오류율 {formatPercent(stats.avg_error_rate || 0)}
                                                             </span>
                                                         </div>


### PR DESCRIPTION
## .stat-item crash:

```
PronunciationErrorModal.css: Change to .modal-stat-item
PronunciationErrorModal.js: Update that class name
```

## .level-item conflict:
```
PronunciationErrorModal.css: Change to .modal-level-item
PronunciationErrorModal.js: Update that class name
```

## .nationality-item conflict (further found):
```
PronunciationErrorModal.css: Change to .modal-nationality-item
PronunciationErrorModal.js: Update that class name
````

## Modify related classes as well:
```
.stat-value → .modal-stat-value
.stat-label → .modal-stat-label
.level-name → .modal-level-name
.level-stats → .modal-level-stats
.nationality-name → .modal-nationality-name
.nationality-stats → .modal-nationality-stats
```